### PR TITLE
status badge の URL を更新した

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Bento [![Build Status](https://travis-ci.org/colorbox/bento.svg?branch=master)](https://travis-ci.org/colorbox/bento)
+# Bento [![Build Status](https://travis-ci.org/esminc/bento.svg?branch=master)](https://travis-ci.org/esminc/bento)
 
 社内向けお弁当注文システムです。
 


### PR DESCRIPTION
## やったこと

esminc org に transfer されたので、status badge の URL が変わったことへ対応しました。

確認は、 README の `view` からお願いします。