### PR TITLE
Install Bootsnap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ end
 gem 'rails', '5.1.1'
 
 gem 'airbrake', '~> 5.0' # errbit から、バージョン指定しろとの指示
+gem 'bootsnap'
 gem 'bootstrap-sass'
 gem 'faraday'
 gem 'holiday_jp'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,8 @@ GEM
     ast (2.3.0)
     autoprefixer-rails (6.7.7.2)
       execjs
+    bootsnap (1.1.0)
+      msgpack (~> 1.0)
     bootstrap-sass (3.3.7)
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
@@ -108,6 +110,7 @@ GEM
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
     minitest (5.10.2)
+    msgpack (1.1.0)
     multipart-post (2.0.0)
     nio4r (2.0.0)
     nokogiri (1.7.2)
@@ -239,6 +242,7 @@ PLATFORMS
 DEPENDENCIES
   airbrake (~> 5.0)
   annotate
+  bootsnap
   bootstrap-sass
   bullet
   capybara

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,5 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
+
+require 'bootsnap/setup' # Speed up boot time by caching expensive operations.


### PR DESCRIPTION
アプリケーション起動の高速化のため Shopify や Mastodon での実績のある Gem を導入しました。

https://github.com/Shopify/bootsnap

rails console の起動時間を 50% ほど削減するなどパフォーマンスの向上を確認できてます。