### PR TITLE
Update for new menu

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -11,7 +11,7 @@
 
 class Order < ApplicationRecord
   SHOW_COUNT = 10
-  MINIMUM_ORDER_ITEM_COUNT = 3
+  MINIMUM_ORDER_ITEM_COUNT = 1
 
   has_many :order_items, dependent: :destroy
 

--- a/db/fixtures/lunchboxes.rb
+++ b/db/fixtures/lunchboxes.rb
@@ -1,4 +1,5 @@
 Lunchbox.seed(:id,
   {id: 1, name: 'ヘルシー', price: 400},
   {id: 2, name: 'デラックス', price: 500},
+  {id: 2, name: 'デラックス(ライス大盛り)', price: 500}
 )


### PR DESCRIPTION
下記対応を行いました。

 - 注文成立の最小個数の変更
 - `ライス大盛り`をfixtureに追加

注文成立に関する部分は不要となるのでそもそもコードごと消すべきでは？とも思いましたが、一旦保留&最小工数で対応したかったのでこのような修正にしました。

[closes #162]
