### PR TITLE
Replace factory_girl with factory_bot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ end
 group :test do
   gem 'capybara'
   gem 'database_rewinder'
-  gem 'factory_girl_rails'
+  gem 'factory_bot_rails'
   gem 'ffaker'
   gem 'launchy'
   gem 'rspec-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,11 +83,11 @@ GEM
       railties (>= 3.2, < 6.1)
     erubi (1.8.0)
     execjs (2.7.0)
-    factory_girl (4.9.0)
-      activesupport (>= 3.0.0)
-    factory_girl_rails (4.9.0)
-      factory_girl (~> 4.9.0)
-      railties (>= 3.0.0)
+    factory_bot (5.0.2)
+      activesupport (>= 4.2.0)
+    factory_bot_rails (5.0.2)
+      factory_bot (~> 5.0.2)
+      railties (>= 4.2.0)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     ffaker (2.10.0)
@@ -266,7 +266,7 @@ DEPENDENCIES
   capybara
   database_rewinder
   dotenv-rails
-  factory_girl_rails
+  factory_bot_rails
   faraday
   ffaker
   holiday_jp
@@ -291,4 +291,4 @@ RUBY VERSION
    ruby 2.5.5p157
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/spec/factories/lunchboxes.rb
+++ b/spec/factories/lunchboxes.rb
@@ -9,9 +9,9 @@
 #  updated_at :datetime         not null
 #
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :lunchbox do
-    name 'sample弁当'
-    price 400
+    name { 'sample弁当' }
+    price { 400 }
   end
 end

--- a/spec/factories/order_items.rb
+++ b/spec/factories/order_items.rb
@@ -11,8 +11,8 @@
 #  updated_at    :datetime         not null
 #
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :order_item do
-    customer_name 'テスト'
+    customer_name { 'テスト' }
   end
 end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -9,12 +9,12 @@
 #  updated_at :datetime         not null
 #
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :order do
-    date Time.zone.local(2017, 2, 1)
+    date { Time.zone.local(2017, 2, 1) }
 
     trait :closed do
-      closed_at Time.zone.local(2017, 2, 1, 9, 20)
+      closed_at { Time.zone.local(2017, 2, 1, 9, 20) }
     end
   end
 end

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -1,1 +1,1 @@
-include FactoryGirl::Syntax::Methods
+include FactoryBot::Syntax::Methods


### PR DESCRIPTION
テスト流すと以下のログが出てて気になったので、取り急ぎ出てこないように直しました。

```
DEPRECATION WARNING: The factory_girl gem is deprecated. Please upgrade to factory_bot. See https://github.com/thoughtbot/factory_bot/blob/v4.9.0/UPGRADE_FROM_FACTORY_GIRL.md for further instructions. (called from <top (required)> at /bento/config/application.rb:7)
```

直した時に参考にしたもの

- https://github.com/thoughtbot/factory_bot/blob/v4.9.0/UPGRADE_FROM_FACTORY_GIRL.md
- https://github.com/thoughtbot/factory_bot_rails/issues/315#issuecomment-461094106